### PR TITLE
Accept an array of codepoints as well as strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,19 +3,19 @@ var Converter = require('./src/converter');
 /**
  * Function get source and destination alphabet and return convert function
  *
- * @param {string} srcAlphabet
- * @param {string} dstAlphabet
+ * @param {string|Array} srcAlphabet
+ * @param {string|Array} dstAlphabet
  *
- * @returns {function(number)}
+ * @returns {function(number|Array)}
  */
 function anyBase(srcAlphabet, dstAlphabet) {
     var converter = new Converter(srcAlphabet, dstAlphabet);
     /**
      * Convert function
      *
-     * @param {string} number
+     * @param {string|Array} number
      *
-     * @return {string} number
+     * @return {string|Array} number
      */
     return function (number) {
         return converter.convert(number);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {},
   "devDependencies": {
     "browserify": "^13.1.1",
+    "punycode": "^2.1.0",
     "uglify-js": "^2.7.4",
     "watchify": "^3.7.0"
   }

--- a/src/converter.js
+++ b/src/converter.js
@@ -3,8 +3,8 @@
 /**
  * Converter
  *
- * @param {string} srcAlphabet
- * @param {string} dstAlphabet
+ * @param {string|Array} srcAlphabet
+ * @param {string|Array} dstAlphabet
  * @constructor
  */
 function Converter(srcAlphabet, dstAlphabet) {
@@ -16,11 +16,11 @@ function Converter(srcAlphabet, dstAlphabet) {
 }
 
 /**
- * Convert number from source alphabet to destonation alphabet
+ * Convert number from source alphabet to destination alphabet
  *
- * @param {string} number - number represent as a string
+ * @param {string|Array} number - number represented as a string or array of points
  *
- * @returns {string}
+ * @returns {string|Array}
  */
 Converter.prototype.convert = function(number) {
     var i, divide, newlen,
@@ -28,7 +28,7 @@ Converter.prototype.convert = function(number) {
     fromBase = this.srcAlphabet.length,
     toBase = this.dstAlphabet.length,
     length = number.length,
-    result = '';
+    result = typeof number === 'string' ? '' : [];
 
     if (this.srcAlphabet === this.dstAlphabet) {
         return number;
@@ -50,7 +50,7 @@ Converter.prototype.convert = function(number) {
             }
         }
         length = newlen;
-        result = this.dstAlphabet[divide] + result;
+        result = this.dstAlphabet.slice(divide, divide + 1).concat(result);
     } while (newlen != 0);
 
     return result;

--- a/tests/test.js
+++ b/tests/test.js
@@ -13,9 +13,11 @@ function test (a, b, desc) {
         console.log('\033[32mOK: ' + desc + '\033[0m');
     } else {
         console.error('\033[31mFAIL: ' + desc + '\033[0m');
+        console.error('\t\033[31m"' + a + '" doesn\'t match "' + b + '"');
     }
 }
 
+// Standard numeric string tests
 test(hex2bin.convert('2d5e'), '10110101011110', 'hex2bin(2d5e) === 10110101011110');
 test(bin2hex.convert('10110101011110'), '2d5e', 'hex2bin(10110101011110) === 2d5e');
 test(dec2hex.convert('11614'), '2d5e', 'hex2bin(11614) === 2d5e');
@@ -25,3 +27,40 @@ test(dec2otc.convert('11614'), '26536', 'hex2bin(11614) === 26536');
 
 var short = shorter.convert('123456789123456789');
 test(unshorter.convert(short), '123456789123456789', 'unshorter(shorter(123456789123456789)) === 123456789123456789');
+
+// UTF-8 codepoint compatibility tests
+var ucs2 = require('punycode').ucs2;
+var dec2moji = new Converter(
+  ucs2.decode('0123456789'),
+  ucs2.decode(
+    '😀😃😄😁😆😅😂🤣☺😊😇🙂🙃😉😌😍😘😗😙😚😋😜😝😛🤑🤗🤓😎😏😒😞😔😟😕🙁☹😣😖😫😩😤😠😡😶😐😑😯😦😧😮😲😵😳😱😨😰😢😥😴🤤😭😓😪🙄'
+  )
+);
+var hex2moji = new Converter(
+  ucs2.decode('0123456789abcdef'),
+  ucs2.decode(
+    '😀😃😄😁😆😅😂🤣☺😊😇🙂🙃😉😌😍😘😗😙😚😋😜😝😛🤑🤗🤓😎😏😒😞😔😟😕🙁☹😣😖😫😩😤😠😡😶😐😑😯😦😧😮😲😵😳😱😨😰😢😥😴🤤😭😓😪🙄'
+  )
+);
+var moji2hex = new Converter(
+  ucs2.decode(
+    '😀😃😄😁😆😅😂🤣☺😊😇🙂🙃😉😌😍😘😗😙😚😋😜😝😛🤑🤗🤓😎😏😒😞😔😟😕🙁☹😣😖😫😩😤😠😡😶😐😑😯😦😧😮😲😵😳😱😨😰😢😥😴🤤😭😓😪🙄'
+  ),
+  ucs2.decode('0123456789abcdef')
+);
+
+test(
+  ucs2.encode(dec2moji.convert(ucs2.decode('11614'))),
+  '😄😱😞',
+  'ucs2.encode(dec2moji.convert(ucs2.decode(11614))) === 😄😱😞'
+);
+test(
+  ucs2.encode(hex2moji.convert(ucs2.decode('2d5e'))),
+  '😄😱😞',
+  'ucs2.encode(hex2moji.convert(ucs2.decode(2d5e))) === 😄😱😞'
+);
+test(
+  ucs2.encode(moji2hex.convert(ucs2.decode('😄😱😞'))),
+  '2d5e',
+  'ucs2.encode(moji2hex.convert(ucs2.decode(😄😱😞))) === 2d5e'
+);

--- a/tests/test.js
+++ b/tests/test.js
@@ -13,7 +13,7 @@ function test (a, b, desc) {
         console.log('\033[32mOK: ' + desc + '\033[0m');
     } else {
         console.error('\033[31mFAIL: ' + desc + '\033[0m');
-        console.error('\t\033[31m"' + a + '" doesn\'t match "' + b + '"');
+        console.error('\t\033[31m"\033[0m' + a + '\033[31m" doesn\'t match "\033[0m' + b + '\033[31m"\033[0m');
     }
 }
 


### PR DESCRIPTION
This allows for using UTF-8 codepoints in conversion, thus allowing use of things like emoji or other astral plane characters which are otherwise two UCS-2 surrogates, and thus not necessarily valid emoji in all combinations.

This commit doesn't stop string-based alphabets and conversions from working, just makes use of the similarities between Arrays and Strings in JavaScript to make the algorithm generic enough for both. It should probably also check all inputs are the same type before operating on them but it probably doesn't matter _too_ much.